### PR TITLE
Unused field fix.

### DIFF
--- a/src-tauri/src/commands/import.rs
+++ b/src-tauri/src/commands/import.rs
@@ -245,9 +245,14 @@ fn import_entries(
 ) -> Result<ImportResult, String> {
     let mut entries_imported = 0;
     let mut entries_merged = 0;
-    let entries_skipped = 0;
+    let mut entries_skipped = 0;
 
     for entry in entries {
+        // Skip entries with no meaningful content
+        if entry.title.trim().is_empty() && entry.text.trim().is_empty() {
+            entries_skipped += 1;
+            continue;
+        }
         // Check if entry already exists
         let existing = queries::get_entry(db, &entry.date)?;
 


### PR DESCRIPTION
## Summary

The entries_skipped field is declared but never used, so I added a condition in the for loop to skip and count entries that have no meaningful content rather than inserting empty records

## Changes

- Change 1
- Change 2

## Testing

- [ ] `bun run lint` passes
- [ ] `bun run format:check` passes
- [ ] `bun run type-check` passes
- [ ] `bun run test:run` passes
- [x] `cargo test` passes (in src-tauri/)
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] Manual testing done

## Related Issues

Closes #
