### PR TITLE
Potential fix for code scanning alert no. 140: Incomplete multi-character sanitization

### DIFF
--- a/scripts/enrich-winget-manifest.mjs
+++ b/scripts/enrich-winget-manifest.mjs
@@ -42,6 +42,16 @@ function stripMarkdownFormatting(text) {
     .replace(/_([^_]+)_/g, '$1');
 }
 
+function removeHtmlComments(text) {
+  let previous;
+  let current = text;
+  do {
+    previous = current;
+    current = current.replace(/<!--[\s\S]*?-->/g, '');
+  } while (current !== previous);
+  return current;
+}
+
 function wrapLine(line, width = 100) {
   if (!line || line.length <= width) {
     return [line];
@@ -84,9 +94,9 @@ function wrapLine(line, width = 100) {
 }
 
 export function normalizeReleaseNotes(markdown) {
-  const normalizedLines = markdown
-    .replace(/\r\n/g, '\n')
-    .replace(/<!--[\s\S]*?-->/g, '')
+  const normalizedLines = removeHtmlComments(
+    markdown.replace(/\r\n/g, '\n')
+  )
     .split('\n')
     .map((line) => line.trimEnd())
     .filter((line, index, lines) => !(line === '' && lines[index - 1] === ''))


### PR DESCRIPTION
Potential fix for [https://github.com/fjrevoredo/mini-diarium/security/code-scanning/140](https://github.com/fjrevoredo/mini-diarium/security/code-scanning/140)

In general, to fix incomplete multi-character sanitization, you should either (1) use a well-tested sanitization library that can robustly remove or escape unsafe constructs, or (2) ensure that multi-character patterns such as `<!-- ... -->` are removed to a fixed point by repeatedly applying the replacement until no further matches are found, or by switching to a simpler, single-character-based approach that removes the building blocks (`<`, `>`) of those constructs.

For this code, the minimal and safest change without altering intended functionality of `normalizeReleaseNotes` is to ensure that HTML comments are fully stripped, even if intermediate transformations might accidentally reconstruct them. We can achieve this by extracting the comment-stripping logic into a small helper, `removeHtmlComments`, that repeatedly applies the same regex until no more replacements occur. Then, inside `normalizeReleaseNotes`, we call this helper instead of performing a single `.replace(/<!--[\s\S]*?-->/g, '')`. This keeps behavior consistent with the original intent (remove HTML comments) while closing the multi-character sanitization hole, and it requires no external dependencies or changes to imports.

Concretely:
- Add a new function `removeHtmlComments(text)` near the other helper functions (e.g., after `stripMarkdownFormatting`), using a `do { ... } while` loop to repeatedly call `text.replace(/<!--[\s\S]*?-->/g, '')` until the string no longer changes.
- In `normalizeReleaseNotes`, change the initial comment-stripping stage from the inline `.replace(/<!--[\s\S]*?-->/g, '')` to a call to `removeHtmlComments(...)`.
- Leave all other logic unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
