### PR TITLE
fix(editor): drop duplicate underline extension and guard focus-on-unlock race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ Template:
 
 # Versions
 
+## [Unreleased]
+
+### Fixed
+- **Duplicate editor extension warning**: the rich-text editor no longer registers `@tiptap/extension-underline` separately. TipTap StarterKit v3 already bundles the Underline extension, so the standalone registration produced a `Duplicate extension names found: ['underline']` console warning on every editor mount. Underline functionality is unchanged.
+- **Editor focus crash on lock/unlock**: fixed an unhandled `TypeError: null is not an object (evaluating 'this.commandManager.commands')` that could fire when locking and unlocking the journal in quick succession. The auto-focus effect schedules a `requestAnimationFrame`, but a lock could destroy the editor before that frame ran; the callback now re-checks that the editor is still alive (and still the current instance) before calling `focus()`. The title-bar Enter handler got the same `isDestroyed` guard.
+
 ## [0.5.2] - 29-05-2026
 
 ### Added

--- a/src/components/editor/DiaryEditor.tsx
+++ b/src/components/editor/DiaryEditor.tsx
@@ -2,7 +2,6 @@ import { createEffect, onCleanup, onMount, createSignal, createResource, Show } 
 import { Editor } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
 import Placeholder from '@tiptap/extension-placeholder';
-import Underline from '@tiptap/extension-underline';
 import Highlight from '@tiptap/extension-highlight';
 import { TextStyle } from '@tiptap/extension-text-style';
 import Color from '@tiptap/extension-color';
@@ -170,7 +169,8 @@ export default function DiaryEditor(props: DiaryEditorProps) {
         Placeholder.configure({
           placeholder: () => props.placeholder || 'Start writing...',
         }),
-        Underline,
+        // Underline ships with StarterKit v3 — do not register @tiptap/extension-underline
+        // separately or TipTap warns about a duplicate extension name.
         Highlight.configure({ multicolor: true }),
         TextStyle,
         Color,

--- a/src/components/layout/EditorPanel.integration.test.tsx
+++ b/src/components/layout/EditorPanel.integration.test.tsx
@@ -121,6 +121,7 @@ vi.mock('../editor/DiaryEditor', () => {
 import EditorPanel from './EditorPanel';
 import { setSelectedDate } from '../../state/ui';
 import { setIsSaving } from '../../state/entries';
+import { setHasFocusedEditorOnUnlock } from '../../state/session';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -167,6 +168,8 @@ describe('EditorPanel integration', () => {
     mocks.deleteEntry.mockResolvedValue(undefined);
     mocks.confirm.mockResolvedValue(true);
     setSelectedDate('2026-04-23');
+    // Session flag is module-global; reset so each test starts pre-focus.
+    setHasFocusedEditorOnUnlock(false);
     vi.useFakeTimers({ shouldAdvanceTime: true });
   });
 
@@ -346,5 +349,52 @@ describe('EditorPanel integration', () => {
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
     expect(screen.getByText('permission denied')).toBeInTheDocument();
     expect(mocks.saveEntry).not.toHaveBeenCalled();
+  });
+
+  it('focus-on-unlock: does not focus an editor destroyed between scheduling and the frame', async () => {
+    // Regression: the auto-focus effect schedules a requestAnimationFrame, but a lock
+    // can tear the editor down before the frame fires (resetting hasFocusedEditorOnUnlock
+    // re-runs the effect, then the teardown nulls TipTap's commandManager). Calling
+    // ed.commands.focus() on that destroyed editor threw
+    // "null is not an object (evaluating 'this.commandManager.commands')".
+    const rafQueue: FrameRequestCallback[] = [];
+    const realRaf = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    }) as typeof globalThis.requestAnimationFrame;
+    const flushFrames = () => {
+      const pending = rafQueue.splice(0);
+      pending.forEach((cb) => cb(0));
+    };
+
+    try {
+      mocks.getEntriesForDate.mockResolvedValue([]);
+      renderWithI18n(() => <EditorPanel />);
+      await waitFor(() => expect(mocks.getEntriesForDate).toHaveBeenCalledWith('2026-04-23'));
+      await flushMicrotasks();
+
+      // The first (legitimate) auto-focus frame fires while the editor is alive.
+      flushFrames();
+      await flushMicrotasks();
+      expect(bus.mockEditor.isDestroyed).toBe(false);
+
+      // Swap in a spy and simulate a lock: the flag reset re-runs the effect, which
+      // passes the synchronous guard (editor still alive) and schedules a frame.
+      const focusSpy = vi.fn();
+      bus.mockEditor.commands.focus = focusSpy;
+      setHasFocusedEditorOnUnlock(false);
+      await flushMicrotasks();
+      expect(rafQueue.length).toBeGreaterThan(0);
+
+      // Teardown happens after the frame is queued but before it runs.
+      bus.mockEditor.isDestroyed = true;
+      flushFrames();
+
+      // The re-check inside the frame must skip focus on the destroyed editor.
+      expect(focusSpy).not.toHaveBeenCalled();
+    } finally {
+      globalThis.requestAnimationFrame = realRaf;
+    }
   });
 });

--- a/src/components/layout/EditorPanel.tsx
+++ b/src/components/layout/EditorPanel.tsx
@@ -97,6 +97,11 @@ export default function EditorPanel() {
     const ed = editorInstance();
     if (!ed || ed.isDestroyed || hasFocusedEditorOnUnlock()) return;
     requestAnimationFrame(() => {
+      // Re-check teardown state: the editor can be destroyed between scheduling and
+      // firing this callback (e.g. a lock resets hasFocusedEditorOnUnlock, re-running
+      // this effect, then tears the editor down before the frame runs). A destroyed
+      // editor has commandManager === null, so ed.commands.focus() would throw.
+      if (ed.isDestroyed || editorInstance() !== ed) return;
       if (!hasFocusedEditorOnUnlock()) {
         ed.commands.focus('end');
         setHasFocusedEditorOnUnlock(true);
@@ -147,7 +152,7 @@ export default function EditorPanel() {
 
   const handleTitleEnter = () => {
     const editor = editorInstance();
-    if (editor) {
+    if (editor && !editor.isDestroyed) {
       editor.commands.focus('end');
     }
   };


### PR DESCRIPTION
## Summary

Two editor bugs that surface while running the app (both observed in the dev console):

### 1. Duplicate `underline` extension warning
`DiaryEditor` registered `@tiptap/extension-underline` separately, but **StarterKit v3 already bundles the Underline extension**. The duplicate registration produced this warning on every editor mount:

```
[tiptap warn]: Duplicate extension names found: ['underline']. This can lead to issues.
```

Removed the standalone import/registration (left a comment so it isn't re-added). Underline functionality is unchanged — it's the same extension, just no longer registered twice.

### 2. `TypeError` crash on lock/unlock
The auto-focus-on-unlock effect schedules a `requestAnimationFrame`, but a lock can destroy the editor before that frame runs: resetting `hasFocusedEditorOnUnlock` re-runs the effect (passing the synchronous `isDestroyed` guard while the editor is still alive), schedules a frame, and then teardown nulls TipTap's `commandManager`. The callback then called `focus()` on the destroyed editor:

```
TypeError: null is not an object (evaluating 'this.commandManager.commands')
 > EditorPanel.tsx: ed.commands.focus('end')
```

The rAF callback now re-checks `isDestroyed` / stale instance before focusing. The title-bar Enter handler got the same `isDestroyed` guard for consistency.

## Test plan

- Added an `EditorPanel` integration regression test that reproduces the exact rAF teardown race (editor destroyed between scheduling and the frame). It **fails without the guard** (focus is called on the destroyed editor) and **passes with it**.
- `bun run type-check` — clean
- `bun run lint` + `prettier --check` on the changed files — clean
- Editor test suite passes (8/8 in `EditorPanel.integration.test.tsx`).

Frontend-only change — no Rust touched.

> Note: I'm on macOS with Node 26, where a handful of `localStorage`-based tests (`notifications`, `theme-overrides`, preferences) fail for everyone on a clean `master` checkout because Node needs `--localstorage-file`. Those are unrelated to this PR and pre-exist it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)