### PR TITLE
Add Nix flake packaging with NixOS and Home Manager modules

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ flatpak/node-sources.json
 
 # tauri-agent-dev runtime state + sandbox
 .agent-dev/
+
+.direnv/
+result

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,7 +210,10 @@ Use the `update-app-icons` skill. Source SVG: `public/logo-transparent.svg` (102
 ### Updating Dependencies (npm/bun)
 
 Use the `sync-lockfiles` skill. Both `bun.lock` and `package-lock.json` must be committed
-together after any `package.json` change.
+together after any `package.json` change. Also refresh `npmDepsHash` in
+[nix/package.nix](nix/package.nix) whenever `package-lock.json` changes — compute it with
+`nix run nixpkgs#prefetch-npm-deps -- package-lock.json` (or copy the `got:` hash from a
+failing `nix build .#default`).
 
 ### Creating a Release
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,57 @@ Quick install:
 - Windows (WinGet): `winget install fjrevoredo.MiniDiarium`
 - macOS (Homebrew): `brew tap fjrevoredo/mini-diarium` then `brew install --cask mini-diarium`
 - Linux (Flatpak): `flatpak install flathub io.github.fjrevoredo.mini-diarium`
+- NixOS / Nix (Flakes): see [Install with Nix](#install-with-nix-flakes)
 
 For package formats, first-run notes (Gatekeeper / SmartScreen), and checksum verification, see [docs/INSTALLATION.md](docs/INSTALLATION.md).
+
+### Install with Nix (Flakes)
+
+Mini Diarium ships a flake that builds it straight from this repository (Linux only: `x86_64-linux`, `aarch64-linux`). Flakes must be enabled (`experimental-features = nix-command flakes`).
+
+Try it without installing:
+
+```bash
+nix run github:fjrevoredo/mini-diarium
+```
+
+Add the flake as an input, then choose one of the three integration styles:
+
+```nix
+{
+  inputs.mini-diarium.url = "github:fjrevoredo/mini-diarium";
+  # Optional: avoid a second nixpkgs copy.
+  inputs.mini-diarium.inputs.nixpkgs.follows = "nixpkgs";
+}
+```
+
+**1. Bare package** — add it to any package list:
+
+```nix
+environment.systemPackages = [ inputs.mini-diarium.packages.${pkgs.system}.default ]; # NixOS
+# or, for Home Manager:
+home.packages = [ inputs.mini-diarium.packages.${pkgs.system}.default ];
+```
+
+**2. NixOS module:**
+
+```nix
+{
+  imports = [ inputs.mini-diarium.nixosModules.default ];
+  programs.mini-diarium.enable = true;
+}
+```
+
+**3. Home Manager module:**
+
+```nix
+{
+  imports = [ inputs.mini-diarium.homeModules.default ];
+  programs.mini-diarium.enable = true;
+}
+```
+
+An overlay is also exported as `mini-diarium.overlays.default` (adds `pkgs.mini-diarium`).
 
 ## Quick Start
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "Mini Diarium — an encrypted, local-first desktop journaling application";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (
+        _system: pkgs: rec {
+          mini-diarium = pkgs.callPackage ./nix/package.nix { };
+          default = mini-diarium;
+        }
+      );
+
+      overlays.default = final: _prev: {
+        mini-diarium = final.callPackage ./nix/package.nix { };
+      };
+
+      nixosModules.default = import ./nix/nixos-module.nix self;
+      homeModules.default = import ./nix/hm-module.nix self;
+
+      devShells = forAllSystems (
+        system: pkgs: {
+          default = pkgs.mkShell {
+            inputsFrom = [ self.packages.${system}.default ];
+            packages = with pkgs; [
+              nodejs
+              bun
+              cargo
+              rustc
+              rust-analyzer
+            ];
+          };
+        }
+      );
+
+      formatter = forAllSystems (_system: pkgs: pkgs.nixfmt);
+    };
+}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,24 @@
+self:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.mini-diarium;
+in
+{
+  options.programs.mini-diarium = {
+    enable = lib.mkEnableOption "Mini Diarium, an encrypted local-first journaling app";
+
+    package = lib.mkPackageOption self.packages.${pkgs.stdenv.hostPlatform.system} "mini-diarium" {
+      default = "default";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+  };
+}

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,0 +1,24 @@
+self:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.mini-diarium;
+in
+{
+  options.programs.mini-diarium = {
+    enable = lib.mkEnableOption "Mini Diarium, an encrypted local-first journaling app";
+
+    package = lib.mkPackageOption self.packages.${pkgs.stdenv.hostPlatform.system} "mini-diarium" {
+      default = "default";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,167 @@
+{
+  lib,
+  buildNpmPackage,
+  rustPlatform,
+  pkg-config,
+  wrapGAppsHook3,
+  makeWrapper,
+  webkitgtk_4_1,
+  gtk3,
+  glib,
+  cairo,
+  pango,
+  atk,
+  gdk-pixbuf,
+  librsvg,
+  libsoup_3,
+  dbus,
+  openssl,
+}:
+
+let
+  version = (lib.importJSON ../package.json).version;
+
+  # Linux desktop conventions use the reverse-DNS id from data/linux/, which
+  # differs from tauri.conf.json's `com.minidiarium`.
+  appId = "io.github.fjrevoredo.mini-diarium";
+
+  src = lib.cleanSourceWith {
+    src = ../.;
+    filter =
+      path: type:
+      let
+        rel = lib.removePrefix (toString ../. + "/") (toString path);
+      in
+      !(
+        rel == "node_modules"
+        || lib.hasPrefix "node_modules/" rel
+        || rel == "dist"
+        || lib.hasPrefix "dist/" rel
+        || rel == "src-tauri/target"
+        || lib.hasPrefix "src-tauri/target/" rel
+        || rel == "result"
+        || lib.hasPrefix "result/" rel
+        # The Nix files themselves don't affect the build, so editing them
+        # shouldn't invalidate the (expensive) Rust+npm build. Markdown is NOT
+        # excluded: src/plugin/rhai_loader.rs include_str!()s a docs/*.md file.
+        || rel == "flake.nix"
+        || rel == "flake.lock"
+        || rel == "nix"
+        || lib.hasPrefix "nix/" rel
+      );
+  };
+
+  # Stage 1: build the SolidJS frontend (vite) into dist/.
+  frontend = buildNpmPackage {
+    pname = "mini-diarium-frontend";
+    inherit version src;
+
+    # Refresh this whenever package-lock.json changes:
+    #   nix build .#default  (copy the "got:" hash on mismatch)
+    npmDepsHash = "sha256-apHQDmn10ROPUkmhiKjz+PWeI6+k3RMqbrpVahqNmys=";
+
+    # The repo pins peer-dependency overrides; npm needs the legacy resolver.
+    npmFlags = [ "--legacy-peer-deps" ];
+
+    # esbuild ships its platform binary as a locked optionalDependency
+    # (@esbuild/linux-*), so npm installs it offline from the cache — no
+    # ESBUILD_BINARY_PATH override (which would force a version mismatch).
+    # Skip the puppeteer chromium download (mermaid-cli dev dependency).
+    PUPPETEER_SKIP_DOWNLOAD = "1";
+
+    # Only the web assets are needed; the tauri CLI / native bits are unused here.
+    npmBuildScript = "build";
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r dist $out/dist
+      runHook postInstall
+    '';
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "mini-diarium";
+  inherit version src;
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = "src-tauri";
+
+  cargoLock = {
+    lockFile = ../src-tauri/Cargo.lock;
+  };
+
+  # Production build must embed the bundled frontend assets.
+  buildFeatures = [ "custom-protocol" ];
+
+  # Tests use direct DB connections and are run via `cargo test`, not as part of
+  # the packaged release build.
+  doCheck = false;
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook3
+    makeWrapper
+  ];
+
+  buildInputs = [
+    webkitgtk_4_1
+    gtk3
+    glib
+    cairo
+    pango
+    atk
+    gdk-pixbuf
+    librsvg
+    libsoup_3
+    dbus
+    openssl
+  ];
+
+  # tauri::generate_context! embeds ../dist (relative to src-tauri) at compile
+  # time, so the built frontend must be present before cargo runs.
+  postPatch = ''
+    rm -rf dist
+    cp -r ${frontend}/dist ./dist
+  '';
+
+  # cargoInstallHook installs the `mini-diarium` binary into $out/bin from the
+  # correct (per-triple) target dir; we add the resources alongside it.
+  postInstall = ''
+    # Bundled fonts — resolved at runtime via MINI_DIARIUM_FONTS_DIR (see wrapper).
+    install -Dm644 -t $out/share/mini-diarium/fonts fonts/*.ttf
+
+    # Desktop integration.
+    install -Dm644 data/linux/${appId}.desktop \
+      $out/share/applications/${appId}.desktop
+    install -Dm644 data/linux/${appId}.metainfo.xml \
+      $out/share/metainfo/${appId}.metainfo.xml
+
+    install -Dm644 src-tauri/icons/32x32.png \
+      $out/share/icons/hicolor/32x32/apps/${appId}.png
+    install -Dm644 src-tauri/icons/128x128.png \
+      $out/share/icons/hicolor/128x128/apps/${appId}.png
+    install -Dm644 src-tauri/icons/128x128@2x.png \
+      $out/share/icons/hicolor/256x256/apps/${appId}.png
+
+    install -Dm644 LICENSE \
+      $out/share/licenses/mini-diarium/LICENSE
+  '';
+
+  # wrapGAppsHook3 collects args here; point the app at the store fonts dir and
+  # work around a common webkitgtk-on-Nix rendering failure.
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --set MINI_DIARIUM_FONTS_DIR "$out/share/mini-diarium/fonts"
+      --set-default WEBKIT_DISABLE_DMABUF_RENDERER 1
+    )
+  '';
+
+  meta = {
+    description = "An encrypted, local-first desktop journaling application";
+    homepage = "https://mini-diarium.com";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "mini-diarium";
+  };
+}


### PR DESCRIPTION
## Summary

Packages Mini Diarium as a **Nix flake** so it can be installed straight from GitHub on Linux (`x86_64-linux`, `aarch64-linux`).

- `nix/package.nix` — two-stage build mirroring the Flatpak recipe: `buildNpmPackage` builds the SolidJS frontend (`vite build` → `dist/`), then `rustPlatform.buildRustPackage` builds the Tauri/Rust binary with the `custom-protocol` feature and the embedded frontend. Installs the bundled fonts, `.desktop` entry, icons, and metainfo, and wraps the binary with `wrapGAppsHook3` to set `MINI_DIARIUM_FONTS_DIR` (so the runtime font selector works without the Tauri bundler) plus `WEBKIT_DISABLE_DMABUF_RENDERER`.
- `flake.nix` — exposes `packages.{x86_64,aarch64}-linux.{default,mini-diarium}`, `overlays.default`, `nixosModules.default`, `homeModules.default`, a dev shell, and a formatter.
- `nix/nixos-module.nix` / `nix/hm-module.nix` — `programs.mini-diarium.enable` (+ `package`) options for NixOS and Home Manager.
- Docs: README "Install with Nix (Flakes)" section (bare package, both modules, `nix run`); `CLAUDE.md` note to refresh `npmDepsHash` when `package-lock.json` changes.
- Tooling: `.envrc` (`use flake`) and `.gitignore` entries for `.direnv/` and `result`.

`rusqlite` uses the `bundled` feature, so no system SQLite is required. No git dependencies in `Cargo.lock`, so `cargoLock.lockFile` is used without `outputHashes`.

### Usage

```nix
# flake input
inputs.mini-diarium.url = "github:fjrevoredo/mini-diarium";

# bare package
environment.systemPackages = [ inputs.mini-diarium.packages.${pkgs.system}.default ];

# NixOS / Home Manager module
imports = [ inputs.mini-diarium.nixosModules.default ]; # or .homeModules.default
programs.mini-diarium.enable = true;
```

## Test plan

- [x] `nix flake check` passes (packages, overlay, both modules, devShell, formatter)
- [x] `nix build .#default` builds end-to-end (frontend + Rust release)
- [x] Built binary launches and links all libraries; wrapper sets `MINI_DIARIUM_FONTS_DIR` to the store fonts dir (14 fonts present); `.desktop`/icons/metainfo installed
- [ ] `aarch64-linux` is wired up but not built/verified by the author (built and run on `x86_64-linux`)

## Notes

- Linux only by design (webkitgtk Tauri app); macOS is out of scope for this change.
- The Linux app id `io.github.fjrevoredo.mini-diarium` (matching `data/linux/`) is used for the desktop/metainfo/icon files.
- `npmDepsHash` must be refreshed whenever `package-lock.json` changes (documented in `CLAUDE.md`).
- The nix modules should be pushed upstream to NixOS's nixpkg repo and Home-Manager ideally. 