### PR TITLE
fix(editor): render bullet/ordered list markers (#163)

### DIFF
--- a/src/styles/editor.css
+++ b/src/styles/editor.css
@@ -79,6 +79,16 @@
   margin: 0.75rem 0;
 }
 
+/* The global reset (@unocss/reset/tailwind.css) sets `list-style: none` on
+   ul/ol, so markers must be restored explicitly inside the editor. */
+.ProseMirror ul {
+  list-style: disc;
+}
+
+.ProseMirror ol {
+  list-style: decimal;
+}
+
 .ProseMirror code {
   background-color: var(--editor-code-bg);
   border-radius: 0.25rem;


### PR DESCRIPTION
Fixes #163 — bullet and numbered lists in the editor showed indentation but no markers (no dots, no numbers) in both light and dark mode.

## Root cause

The global reset `@unocss/reset/tailwind.css` (`src/index.css`) applies Tailwind's preflight, which sets `ol, ul { list-style: none; }`. The editor stylesheet re-adds list padding (`.ProseMirror ul, .ProseMirror ol { padding-inline-start: 1.5rem }`) — which is why indentation appeared — but nothing ever restores `list-style`, so the markers stayed hidden. TipTap StarterKit was creating the list nodes correctly; this was purely CSS.

## Fix

Restore markers, scoped to the editor content only:

```css
.ProseMirror ul { list-style: disc; }
.ProseMirror ol { list-style: decimal; }
```

- Scoped to `.ProseMirror` — does not touch the global reset or other `ul`/`ol` in the app (e.g. the password-requirements list).
- Markers inherit `currentColor` (the editor already sets body text color), so they render correctly in both light and dark themes with no extra theming.
- The editor uses StarterKit only (no task-list extension), so this does not add markers to any checkbox lists.

## Verification

1. Open an entry, create a bullet list (toolbar, `- ` shortcut, or Ctrl+Shift+8) — each line shows a `•`.
2. Create a numbered list — lines show `1. 2. 3.`.
3. Toggle light/dark theme — markers remain visible and match the body text color.
