### PR TITLE
feat(timeline): add timeline list view of entries (#161)

### DIFF
--- a/src-tauri/src/commands/entries.rs
+++ b/src-tauri/src/commands/entries.rs
@@ -1,7 +1,65 @@
 use crate::commands::auth::{with_unlocked_db, DiaryState};
 use crate::db::queries::{self, DiaryEntry, EntryMetadata};
 use log::debug;
+use serde::Serialize;
 use tauri::State;
+
+/// Maximum number of characters kept in a timeline preview. Keeps full plaintext
+/// off the IPC boundary — only enough to render the first lines of an entry.
+const TIMELINE_PREVIEW_CHARS: usize = 200;
+
+/// A lightweight, read-only row for the timeline list view.
+///
+/// Carries only the date, title, and a short plaintext preview — never the full
+/// decrypted entry text. Built in memory from decrypted entries and dropped after
+/// serialization (nothing is persisted).
+#[derive(Debug, Clone, Serialize)]
+pub struct TimelineEntry {
+    pub id: i64,
+    pub date: String,
+    pub title: String,
+    pub preview: String,
+}
+
+/// Builds a short plaintext preview from an entry's stored HTML text.
+///
+/// Strips HTML tags, decodes the handful of common entities the editor emits,
+/// collapses whitespace, and truncates to `TIMELINE_PREVIEW_CHARS` characters so
+/// only the first lines reach the frontend.
+fn preview_from_html(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut in_tag = false;
+    for ch in html.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => {
+                in_tag = false;
+                // Treat block boundaries as spaces so words don't run together.
+                out.push(' ');
+            }
+            _ if in_tag => {}
+            _ => out.push(ch),
+        }
+    }
+
+    let decoded = out
+        .replace("&nbsp;", " ")
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'");
+
+    // Collapse runs of whitespace into single spaces and trim.
+    let collapsed = decoded.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    if collapsed.chars().count() > TIMELINE_PREVIEW_CHARS {
+        let truncated: String = collapsed.chars().take(TIMELINE_PREVIEW_CHARS).collect();
+        format!("{}…", truncated.trim_end())
+    } else {
+        collapsed
+    }
+}
 
 /// Creates a new blank diary entry for the given date and returns it with its assigned id
 #[tauri::command]
@@ -102,6 +160,30 @@ pub fn delete_entry(id: i64, state: State<DiaryState>) -> Result<(), String> {
 #[tauri::command]
 pub fn get_all_entry_dates(state: State<DiaryState>) -> Result<Vec<String>, String> {
     with_unlocked_db(&state, queries::get_all_entry_dates)
+}
+
+/// Gets a lightweight, newest-first list of all entries for the timeline view.
+///
+/// Decrypts every entry in memory via `queries::get_all_entries`, then keeps only
+/// the date, title, and a short plaintext preview. The full decrypted text is
+/// dropped here and never sent to the frontend or persisted.
+#[tauri::command]
+pub fn get_timeline_entries(state: State<DiaryState>) -> Result<Vec<TimelineEntry>, String> {
+    with_unlocked_db(&state, |db| {
+        let mut entries = queries::get_all_entries(db)?;
+        // get_all_entries returns date ASC, id ASC; the timeline shows newest first.
+        entries.reverse();
+        let timeline = entries
+            .into_iter()
+            .map(|entry| TimelineEntry {
+                id: entry.id,
+                date: entry.date,
+                title: entry.title,
+                preview: preview_from_html(&entry.text),
+            })
+            .collect();
+        Ok(timeline)
+    })
 }
 
 #[cfg(test)]
@@ -260,6 +342,31 @@ mod tests {
         assert_eq!(dates.len(), 3);
         assert_eq!(dates[0], "2024-01-01");
         assert_eq!(dates[2], "2024-02-01");
+    }
+
+    #[test]
+    fn test_preview_strips_html_and_collapses_whitespace() {
+        let html = "<h1>Title</h1><p>Hello   <strong>world</strong></p>";
+        assert_eq!(preview_from_html(html), "Title Hello world");
+    }
+
+    #[test]
+    fn test_preview_decodes_entities() {
+        let html = "<p>Tom &amp; Jerry &lt;3</p>";
+        assert_eq!(preview_from_html(html), "Tom & Jerry <3");
+    }
+
+    #[test]
+    fn test_preview_truncates_long_text() {
+        let long = "word ".repeat(100);
+        let html = format!("<p>{}</p>", long);
+        let preview = preview_from_html(&html);
+        assert!(preview.ends_with('…'));
+        // At most TIMELINE_PREVIEW_CHARS content chars plus the ellipsis. A trailing
+        // space at the truncation boundary is trimmed, so the result may be shorter.
+        assert!(preview.chars().count() <= TIMELINE_PREVIEW_CHARS + 1);
+        // It must actually be shorter than the source content.
+        assert!(preview.chars().count() < long.chars().count());
     }
 
     #[test]

--- a/src-tauri/src/commands/entries.rs
+++ b/src-tauri/src/commands/entries.rs
@@ -42,13 +42,15 @@ fn preview_from_html(html: &str) -> String {
         }
     }
 
+    // Decode `&amp;` LAST so a literally-typed entity (stored as e.g. "&amp;lt;") is not
+    // double-decoded into "<" — it must round-trip back to "&lt;".
     let decoded = out
         .replace("&nbsp;", " ")
-        .replace("&amp;", "&")
         .replace("&lt;", "<")
         .replace("&gt;", ">")
         .replace("&quot;", "\"")
-        .replace("&#39;", "'");
+        .replace("&#39;", "'")
+        .replace("&amp;", "&");
 
     // Collapse runs of whitespace into single spaces and trim.
     let collapsed = decoded.split_whitespace().collect::<Vec<_>>().join(" ");
@@ -354,6 +356,14 @@ mod tests {
     fn test_preview_decodes_entities() {
         let html = "<p>Tom &amp; Jerry &lt;3</p>";
         assert_eq!(preview_from_html(html), "Tom & Jerry <3");
+    }
+
+    #[test]
+    fn test_preview_does_not_double_decode_entities() {
+        // A literally-typed "&lt;" is stored as "&amp;lt;"; it must round-trip back to
+        // "&lt;", not be decoded twice into "<".
+        let html = "<p>a &amp;lt; b</p>";
+        assert_eq!(preview_from_html(html), "a &lt; b");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -327,6 +327,7 @@ pub fn run() {
             commands::entries::delete_entry_if_empty,
             commands::entries::delete_entry,
             commands::entries::get_all_entry_dates,
+            commands::entries::get_timeline_entries,
             // Search
             commands::search::search_entries,
             // Navigation

--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { screen, fireEvent } from '@solidjs/testing-library';
+import { renderWithI18n } from '../../test/i18n-test-utils';
+import { mainView, resetUiState } from '../../state/ui';
+
+import Header from './Header';
+
+describe('Header timeline toggle', () => {
+  beforeEach(() => {
+    resetUiState();
+  });
+
+  it('reflects and switches the main view via aria-pressed', () => {
+    renderWithI18n(() => <Header />);
+
+    const toggle = screen.getByTestId('timeline-toggle-button');
+
+    // Default view is the editor: not pressed, labelled "Show timeline".
+    expect(mainView()).toBe('editor');
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    expect(toggle).toHaveAttribute('aria-label', 'Show timeline');
+
+    fireEvent.click(toggle);
+
+    // Now showing the timeline: pressed, labelled "Show editor".
+    expect(mainView()).toBe('timeline');
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    expect(toggle).toHaveAttribute('aria-label', 'Show editor');
+
+    fireEvent.click(toggle);
+
+    expect(mainView()).toBe('editor');
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+  });
+});

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,10 +1,12 @@
 import { createSignal, Show } from 'solid-js';
-import { Menu, Lock, Info, Bell } from 'lucide-solid';
+import { Menu, Lock, Info, Bell, List, PenLine } from 'lucide-solid';
 import {
   selectedDate,
   setIsAboutOpen,
   isSidebarCollapsed,
   setIsNotificationsOpen,
+  mainView,
+  setMainView,
 } from '../../state/ui';
 import { lockJournal } from '../../state/auth';
 import { preferences } from '../../state/preferences';
@@ -60,8 +62,23 @@ export default function Header(props: HeaderProps) {
         <h1 class="text-lg font-semibold text-primary">{formattedDate()}</h1>
       </div>
 
-      {/* Right: About + Notifications + Lock */}
+      {/* Right: Timeline toggle + About + Notifications + Lock */}
       <div class="flex items-center gap-1">
+        <button
+          onClick={() => setMainView(mainView() === 'timeline' ? 'editor' : 'timeline')}
+          class="rounded p-2 hover:bg-hover text-tertiary transition-colors"
+          aria-label={
+            mainView() === 'timeline'
+              ? t('layout.header.showEditor')
+              : t('layout.header.showTimeline')
+          }
+          aria-pressed={mainView() === 'timeline'}
+          data-testid="timeline-toggle-button"
+        >
+          <Show when={mainView() === 'timeline'} fallback={<List size={20} />}>
+            <PenLine size={20} />
+          </Show>
+        </button>
         <button
           data-tour-target="about"
           onClick={() => setIsAboutOpen(true)}

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,10 +1,11 @@
-import { onMount, onCleanup } from 'solid-js';
+import { onMount, onCleanup, Show } from 'solid-js';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { createLogger } from '../../lib/logger';
 import Header from './Header';
 import Sidebar from './Sidebar';
 import EditorPanel from './EditorPanel';
+import Timeline from '../timeline/Timeline';
 import GoToDateOverlay from '../overlays/GoToDateOverlay';
 import PreferencesOverlay from '../overlays/preferences/PreferencesOverlay';
 import StatsOverlay from '../overlays/StatsOverlay';
@@ -16,6 +17,7 @@ import OnboardingTour from '../overlays/OnboardingOverlay';
 import {
   selectedDate,
   setSelectedDate,
+  mainView,
   isSidebarCollapsed,
   setIsSidebarCollapsed,
   isGoToDateOpen,
@@ -200,9 +202,11 @@ export default function MainLayout() {
         {/* Header */}
         <Header showMenu onMenuClick={() => setIsSidebarCollapsed(!isSidebarCollapsed())} />
 
-        {/* Editor panel */}
+        {/* Main panel: editor or timeline list */}
         <main class="flex-1 overflow-hidden">
-          <EditorPanel />
+          <Show when={mainView() === 'timeline'} fallback={<EditorPanel />}>
+            <Timeline />
+          </Show>
         </main>
       </div>
 

--- a/src/components/timeline/Timeline.test.tsx
+++ b/src/components/timeline/Timeline.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@solidjs/testing-library';
+import { renderWithI18n } from '../../test/i18n-test-utils';
+import { setEntryDates } from '../../state/entries';
+import type { TimelineEntry } from '../../lib/tauri';
+
+const mocks = vi.hoisted(() => ({
+  getTimelineEntries: vi.fn(),
+}));
+
+vi.mock('../../lib/tauri', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/tauri')>('../../lib/tauri');
+  return {
+    ...actual,
+    getTimelineEntries: mocks.getTimelineEntries,
+  };
+});
+
+import Timeline from './Timeline';
+
+const ENTRIES: TimelineEntry[] = [
+  { id: 2, date: '2026-02-01', title: 'Second entry', preview: 'A later day' },
+  { id: 1, date: '2026-01-01', title: 'First entry', preview: 'The beginning' },
+];
+
+describe('Timeline', () => {
+  beforeEach(() => {
+    mocks.getTimelineEntries.mockReset();
+    setEntryDates(['2026-01-01', '2026-02-01']);
+  });
+
+  it('renders the list of entries', async () => {
+    mocks.getTimelineEntries.mockResolvedValue(ENTRIES);
+
+    renderWithI18n(() => <Timeline />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Second entry')).toBeInTheDocument();
+    });
+    expect(screen.getByText('First entry')).toBeInTheDocument();
+    expect(screen.getByText('A later day')).toBeInTheDocument();
+    expect(screen.getByText('The beginning')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no entries', async () => {
+    mocks.getTimelineEntries.mockResolvedValue([]);
+
+    renderWithI18n(() => <Timeline />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No entries yet.')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -33,9 +33,7 @@ export default function Timeline() {
       <div class="pt-6 mx-auto w-full max-w-3xl xl:max-w-5xl 2xl:max-w-6xl">
         <h2 class="mb-4 text-xl font-bold text-primary">{t('timeline.title')}</h2>
 
-        <Suspense
-          fallback={<p class="text-sm text-tertiary">{t('layout.loading')}</p>}
-        >
+        <Suspense fallback={<p class="text-sm text-tertiary">{t('layout.loading')}</p>}>
           <Show
             when={(entries() ?? []).length > 0}
             fallback={<p class="text-sm text-tertiary">{t('timeline.empty')}</p>}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -52,7 +52,7 @@ export default function Timeline() {
                         date: formatDate(entry.date, preferences().language),
                       })}
                     >
-                      <span class="w-28 flex-shrink-0 pt-0.5 text-sm font-medium text-tertiary">
+                      <span class="flex-shrink-0 whitespace-nowrap pt-0.5 text-sm font-medium text-tertiary">
                         {formatDate(entry.date, preferences().language)}
                       </span>
                       <span class="min-w-0 flex-1">

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -1,0 +1,78 @@
+import { createResource, For, Show, Suspense } from 'solid-js';
+import { getTimelineEntries } from '../../lib/tauri';
+import type { TimelineEntry } from '../../lib/tauri';
+import { setSelectedDate, setMainView } from '../../state/ui';
+import { entryDates } from '../../state/entries';
+import { formatDate } from '../../lib/dates';
+import { preferences } from '../../state/preferences';
+import { useI18n } from '../../i18n';
+
+/**
+ * Timeline view — a two-column (date | title + preview) list of every entry,
+ * newest first. Complements the calendar by giving a chronological overview.
+ *
+ * Re-fetches whenever the set of entry dates changes (entries added/removed),
+ * so the list stays in sync after edits without manual refresh wiring.
+ */
+export default function Timeline() {
+  const t = useI18n();
+
+  // Keying the resource on entryDates() refreshes the list when entries change.
+  const [entries] = createResource<TimelineEntry[], string[]>(
+    () => entryDates(),
+    () => getTimelineEntries(),
+  );
+
+  const openEntry = (entry: TimelineEntry) => {
+    setSelectedDate(entry.date);
+    setMainView('editor');
+  };
+
+  return (
+    <div class="h-full overflow-y-auto px-6 pb-6">
+      <div class="pt-6 mx-auto w-full max-w-3xl xl:max-w-5xl 2xl:max-w-6xl">
+        <h2 class="mb-4 text-xl font-bold text-primary">{t('timeline.title')}</h2>
+
+        <Suspense
+          fallback={<p class="text-sm text-tertiary">{t('layout.loading')}</p>}
+        >
+          <Show
+            when={(entries() ?? []).length > 0}
+            fallback={<p class="text-sm text-tertiary">{t('timeline.empty')}</p>}
+          >
+            <ul class="divide-y divide-primary rounded-lg border border-primary bg-primary shadow-sm">
+              <For each={entries()}>
+                {(entry) => (
+                  <li>
+                    <button
+                      type="button"
+                      onClick={() => openEntry(entry)}
+                      class="flex w-full gap-4 px-4 py-3 text-left hover:bg-hover"
+                      aria-label={t('timeline.openEntry', {
+                        date: formatDate(entry.date, preferences().language),
+                      })}
+                    >
+                      <span class="w-28 flex-shrink-0 pt-0.5 text-sm font-medium text-tertiary">
+                        {formatDate(entry.date, preferences().language)}
+                      </span>
+                      <span class="min-w-0 flex-1">
+                        <span class="block truncate font-semibold text-primary">
+                          {entry.title.trim() || t('timeline.untitled')}
+                        </span>
+                        <Show when={entry.preview}>
+                          <span class="mt-0.5 block truncate text-sm text-secondary">
+                            {entry.preview}
+                          </span>
+                        </Show>
+                      </span>
+                    </button>
+                  </li>
+                )}
+              </For>
+            </ul>
+          </Show>
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -17,7 +17,9 @@
       "about": "Über",
       "lockJournal": "Tagebuch sperren",
       "notificationsNone": "Benachrichtigungen",
-      "notificationsUnread": "Benachrichtigungen, {{ count }} ungelesen"
+      "notificationsUnread": "Benachrichtigungen, {{ count }} ungelesen",
+      "showTimeline": "Zeitleiste anzeigen",
+      "showEditor": "Editor anzeigen"
     },
     "sidebar": {
       "navigation": "Navigation",
@@ -25,6 +27,12 @@
       "closeMenu": "Menü schließen",
       "goToToday": "Zu heute gehen"
     }
+  },
+  "timeline": {
+    "title": "Zeitleiste",
+    "empty": "Noch keine Einträge.",
+    "untitled": "Ohne Titel",
+    "openEntry": "Eintrag vom {{ date }} öffnen"
   },
   "calendar": {
     "jan": "Jan",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -38,6 +38,8 @@ const en = {
       lockJournal: 'Lock journal',
       notificationsNone: 'Notifications',
       notificationsUnread: 'Notifications, {{ count }} unread',
+      showTimeline: 'Show timeline',
+      showEditor: 'Show editor',
     },
     sidebar: {
       navigation: 'Navigation',
@@ -45,6 +47,14 @@ const en = {
       closeMenu: 'Close menu',
       goToToday: 'Go to Today',
     },
+  },
+
+  /** Timeline list view */
+  timeline: {
+    title: 'Timeline',
+    empty: 'No entries yet.',
+    untitled: 'Untitled',
+    openEntry: 'Open entry from {{ date }}',
   },
 
   /** Calendar widget */

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -17,7 +17,9 @@
       "about": "Acerca de",
       "lockJournal": "Bloquear diario",
       "notificationsNone": "Notificaciones",
-      "notificationsUnread": "Notificaciones, {{ count }} sin leer"
+      "notificationsUnread": "Notificaciones, {{ count }} sin leer",
+      "showTimeline": "Mostrar cronología",
+      "showEditor": "Mostrar editor"
     },
     "sidebar": {
       "navigation": "Navegación",
@@ -25,6 +27,12 @@
       "closeMenu": "Cerrar menú",
       "goToToday": "Ir a hoy"
     }
+  },
+  "timeline": {
+    "title": "Cronología",
+    "empty": "Aún no hay entradas.",
+    "untitled": "Sin título",
+    "openEntry": "Abrir la entrada del {{ date }}"
   },
   "calendar": {
     "jan": "Ene",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -17,7 +17,9 @@
       "about": "À propos",
       "lockJournal": "Verrouiller le journal",
       "notificationsNone": "Notifications",
-      "notificationsUnread": "Notifications, {{ count }} non lues"
+      "notificationsUnread": "Notifications, {{ count }} non lues",
+      "showTimeline": "Afficher la chronologie",
+      "showEditor": "Afficher l'éditeur"
     },
     "sidebar": {
       "navigation": "Navigation",
@@ -25,6 +27,12 @@
       "closeMenu": "Fermer le menu",
       "goToToday": "Aller à aujourd'hui"
     }
+  },
+  "timeline": {
+    "title": "Chronologie",
+    "empty": "Aucune entrée pour le moment.",
+    "untitled": "Sans titre",
+    "openEntry": "Ouvrir l'entrée du {{ date }}"
   },
   "calendar": {
     "jan": "Jan",

--- a/src/i18n/locales/hi.json
+++ b/src/i18n/locales/hi.json
@@ -17,7 +17,9 @@
       "about": "के बारे में",
       "lockJournal": "जर्नल लॉक करें",
       "notificationsNone": "सूचनाएं",
-      "notificationsUnread": "सूचनाएं, {{ count }} अपठित"
+      "notificationsUnread": "सूचनाएं, {{ count }} अपठित",
+      "showTimeline": "टाइमलाइन दिखाएँ",
+      "showEditor": "संपादक दिखाएँ"
     },
     "sidebar": {
       "navigation": "नेविगेशन",
@@ -25,6 +27,12 @@
       "closeMenu": "मेनू बंद करें",
       "goToToday": "आज पर जाएं"
     }
+  },
+  "timeline": {
+    "title": "टाइमलाइन",
+    "empty": "अभी तक कोई प्रविष्टि नहीं।",
+    "untitled": "शीर्षकहीन",
+    "openEntry": "{{ date }} की प्रविष्टि खोलें"
   },
   "calendar": {
     "jan": "जन",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -17,7 +17,9 @@
       "about": "Informazioni",
       "lockJournal": "Blocca diario",
       "notificationsNone": "Notifiche",
-      "notificationsUnread": "Notifiche, {{ count }} non lette"
+      "notificationsUnread": "Notifiche, {{ count }} non lette",
+      "showTimeline": "Mostra cronologia",
+      "showEditor": "Mostra editor"
     },
     "sidebar": {
       "navigation": "Navigazione",
@@ -25,6 +27,12 @@
       "closeMenu": "Chiudi menu",
       "goToToday": "Vai a oggi"
     }
+  },
+  "timeline": {
+    "title": "Cronologia",
+    "empty": "Ancora nessuna voce.",
+    "untitled": "Senza titolo",
+    "openEntry": "Apri la voce del {{ date }}"
   },
   "calendar": {
     "jan": "Gen",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -218,6 +218,19 @@ export async function getAllEntryDates(): Promise<string[]> {
   return await invoke('get_all_entry_dates');
 }
 
+// Timeline view — lightweight list of all entries (date, title, short preview).
+// The full decrypted text never crosses this boundary; preview is built in Rust.
+export interface TimelineEntry {
+  id: number;
+  date: string;
+  title: string;
+  preview: string;
+}
+
+export async function getTimelineEntries(): Promise<TimelineEntry[]> {
+  return await invoke('get_timeline_entries');
+}
+
 // Search commands
 export interface SearchResult {
   date: string;

--- a/src/state/ui.ts
+++ b/src/state/ui.ts
@@ -4,6 +4,10 @@ import { getTodayString } from '../lib/dates';
 // Selected date (YYYY-MM-DD format)
 const [selectedDate, setSelectedDate] = createSignal<string>(getTodayString());
 
+// Main content view: the editor (default) or the timeline list of all entries
+export type MainView = 'editor' | 'timeline';
+const [mainView, setMainView] = createSignal<MainView>('editor');
+
 // Sidebar collapsed state — starts collapsed so the editor is visible immediately on launch/unlock
 const [isSidebarCollapsed, setIsSidebarCollapsed] = createSignal(true);
 
@@ -36,6 +40,7 @@ const [isImagePickerOpen, setIsImagePickerOpen] = createSignal(false);
 
 export function resetUiState(): void {
   setSelectedDate(getTodayString());
+  setMainView('editor');
   setIsSidebarCollapsed(true);
   setIsGoToDateOpen(false);
   setIsPreferencesOpen(false);
@@ -51,6 +56,8 @@ export function resetUiState(): void {
 export {
   selectedDate,
   setSelectedDate,
+  mainView,
+  setMainView,
   isSidebarCollapsed,
   setIsSidebarCollapsed,
   isGoToDateOpen,


### PR DESCRIPTION
Implements #161 — a timeline list view alongside the calendar: every entry, newest-first, shown as `date | title + preview`.

## What's added

- **`get_timeline_entries` command** (`src-tauri/src/commands/entries.rs`): decrypts entries in memory via the existing `queries::get_all_entries`, then returns only `{ id, date, title, preview }`. The preview is built server-side (`preview_from_html`: strips tags, decodes common entities, collapses whitespace, truncates to 200 chars). The full decrypted `text` is dropped here — it never crosses the IPC boundary or gets persisted. Runs under the existing `with_unlocked_db` guard like every other entries command.
- **Frontend** (SolidJS + UnoCSS): a `Timeline` component, a header toggle (List ⇄ PenLine), a `mainView` UI signal, the `getTimelineEntries` wrapper + `TimelineEntry` type, and i18n strings. Clicking a row jumps to that date in the editor.

## Security

Consistent with the project's field-level-encryption model: decryption stays in memory, and only date/title/short-preview reach the frontend — not full entry text.

## Tests / verification

- `cargo test commands::entries` — 13 pass, including 3 new `preview_from_html` tests (tag strip, entity decode, truncation).
- `bun run build` — clean production build (frontend compiles and bundles, UnoCSS classes resolve).

## Notes / limitations

- The list re-fetches when the set of entry dates changes (add/remove). Edits to an existing day's title that don't change the date set won't auto-refresh an open timeline; toggling away and back refetches. This mirrors the calendar's reactivity and keeps the change minimal.
- `preview_from_html` is a lightweight tag stripper (no DOM in Rust), sufficient for previews; it decodes the common entities the editor emits rather than being a full HTML parser.
- Scoped backend-first + UI; happy to adjust styling or placement to your preference.
